### PR TITLE
0.2.1 Updated file input, add manager, navigation, and config

### DIFF
--- a/components/base/FileInput.vue
+++ b/components/base/FileInput.vue
@@ -12,10 +12,16 @@ const { labelDefault } = defineProps({
 
 // Handle File Input
 const emits = defineEmits(["onUpload"]);
+defineExpose({ clear });
 
 const file = ref();
 const data = ref();
 const error = ref("");
+
+// Handle Button Label
+const label = computed(() => {
+  return file.value ? file.value.name : labelDefault;
+});
 
 const handleChange = async (event: Event) => {
   // Guard - No input or files found.
@@ -50,10 +56,11 @@ const handleChange = async (event: Event) => {
   reader.readAsText(input.files[0]);
 };
 
-// Handle Button Label
-const label = computed(() => {
-  return file.value ? file.value.name : labelDefault;
-});
+function clear() {
+  data.value = undefined;
+  file.value = undefined;
+  error.value = "";
+}
 </script>
 
 <template>

--- a/components/form/AddManager.vue
+++ b/components/form/AddManager.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const props = defineProps({
+const { dialog } = defineProps({
   dialog: {
     type: Object as PropType<HTMLDialogElement>,
     default: undefined,
@@ -10,7 +10,7 @@ const props = defineProps({
 const closeDialog = () => {
   managerName.value = "";
   removeError();
-  props.dialog?.close();
+  dialog?.close();
 };
 
 // Manager Name Logic
@@ -22,9 +22,13 @@ const iconList = ["star", "folder", "file-cabinet", "pencil", "car", "gamepad"];
 const selectedIcon = ref("");
 const isSelectingIcon = ref(false);
 
+const updateIsSelectingIcon = (value: boolean) => {
+  isSelectingIcon.value = value;
+};
+
 const selectIcon = (icon: string) => {
   selectedIcon.value = icon;
-  isSelectingIcon.value = false;
+  updateIsSelectingIcon(false);
 };
 
 // Set Random Starting Icon
@@ -78,10 +82,20 @@ const formValidation = (input: string) => {
 // Set Icon Color
 const { themeColor } = useTheme();
 
+const fileInput = ref();
 const data = ref();
-const testing = (event: { file: Object; data: JSON | Object }) => {
+const addData = (event: { file: Object; data: JSON | Object }) => {
   data.value = event.data;
 };
+
+function clearForm() {
+  fileInput.value.clear();
+  managerName.value = "";
+  data.value = undefined;
+  removeError();
+}
+
+defineExpose({ clearForm, isSelectingIcon, updateIsSelectingIcon });
 </script>
 
 <template>
@@ -107,18 +121,22 @@ const testing = (event: { file: Object; data: JSON | Object }) => {
 
       <div class="grid gap-4 place-items-center">
         <span>Select Icon</span>
-        <BaseButton @click="isSelectingIcon = true">
+        <BaseButton @click="updateIsSelectingIcon(true)">
           <span class="sr-only">Close Popup</span>
           <Icon :name="`mdi:${selectedIcon}`" size="32" :color="themeColor" />
         </BaseButton>
       </div>
 
       <div class="grid place-items-center w-full gap-4">
-        <!--  -->
-        <BaseButton class="w-full" type="submit">Create New Manager</BaseButton>
         <!-- Upload Existing File  -->
-        <!-- <BaseButton class="w-full">Upload Existing File</BaseButton> -->
-        <BaseFileInput accept="application/json" @onUpload="testing" />
+        <BaseFileInput
+          ref="fileInput"
+          accept="application/json"
+          @onUpload="addData"
+        />
+
+        <!-- Create Manager -->
+        <BaseButton class="w-full" type="submit">Create New Manager</BaseButton>
       </div>
     </form>
 

--- a/components/sidebar/Navigation.vue
+++ b/components/sidebar/Navigation.vue
@@ -5,7 +5,7 @@ const { managers } = storeToRefs(managerStore);
 const dataManagerStore = useDataManagerStore();
 
 // Handle Dialog Logic
-const modal = ref<HTMLDialogElement>();
+const modal = ref();
 const click = () => {
   modal.value?.show();
 };
@@ -18,6 +18,22 @@ const handleClick = (manager: (typeof managers.value)[number]) => {
   managerStore.setActiveManager(manager.name);
   dataManagerStore.setFilter("");
 };
+
+const form = ref();
+watch(
+  () => modal.value?.visible,
+  (newValue, oldValue) => {
+    if (newValue || !oldValue) return;
+
+    // Revert to add manager form - clear form data.
+    if (form.value.isSelectingIcon) {
+      form.value.updateIsSelectingIcon(false);
+    } else {
+      // Clear Form Data on close
+      form.value.clearForm();
+    }
+  }
+);
 </script>
 
 <template>
@@ -46,7 +62,7 @@ const handleClick = (manager: (typeof managers.value)[number]) => {
   <ClientOnly>
     <Teleport to="#layout">
       <LazyBaseDialog ref="modal" title="Create New Manager">
-        <FormAddManager :dialog="modal" />
+        <FormAddManager ref="form" :dialog="modal" />
       </LazyBaseDialog>
     </Teleport>
   </ClientOnly>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,4 +15,9 @@ export default defineNuxtConfig({
     "@pinia/nuxt",
     "@pinia-plugin-persistedstate/nuxt",
   ],
+  vue: {
+    compilerOptions: {
+      isCustomElement: (tag) => tag.includes("tool-tip"),
+    },
+  },
 });


### PR DESCRIPTION
This branch contains the following updates:

- Nuxt config updated to remove custom element warnings.
- Added an exposed clear function to the base file input to remove data, file, and errors present in the component.
- Updated add manager form to have a clear form function and composable to determine if the form is set to icon selection.
- Updated navigation to reset the add manager form under the user closes the modal.