### PR TITLE
Fixed add manager bug when creating a new manager with no data

### DIFF
--- a/components/form/AddManager.vue
+++ b/components/form/AddManager.vue
@@ -46,7 +46,7 @@ const handleSubmit = () => {
   managerStore.addManager({
     name: managerName.value,
     icon: selectedIcon.value,
-    data: data.value,
+    data: data.value || {},
   });
 
   managerStore.setActiveManager(managerName.value);


### PR DESCRIPTION
This branch contains the following changes:

- Updated the add manager form call to default manager data to an empty object when falsy.