### PR TITLE
0.8.1/feature/property controls

### DIFF
--- a/components/base/Button.vue
+++ b/components/base/Button.vue
@@ -16,19 +16,14 @@ const size = computed(() => {
   switch (props.size) {
     case "xs":
       return "1rem";
-      break;
     case "sm":
       return "1.5rem";
-      break;
     case "md":
       return "2rem";
-      break;
     case "lg":
       return "4rem";
-      break;
     case "xl":
       return "8rem";
-      break;
   }
 });
 </script>

--- a/components/base/Card.vue
+++ b/components/base/Card.vue
@@ -219,6 +219,7 @@ const updatePropertyValue = (
       <div
         v-for="(propertyValue, propertyKey, index) of data.value"
         :key="propertyKey"
+        class="py-[1px]"
       >
         <span class="flex gap-1.5">
           <strong
@@ -248,6 +249,36 @@ const updatePropertyValue = (
             @keypress.enter="(event: Event) => updatePropertyValue(event, index, 'update:property-value')"
             @focusout="handleFocusout"
           />
+
+          <!-- Property buttons -->
+          <ul
+            v-if="isEditingCard.status"
+            class="ml-auto flex gap-1.5 items-center"
+          >
+            <!-- Copy Button -->
+            <li>
+              <BaseButton
+                size="xs"
+                bg-color="var(--surface-lightened)"
+                class="!rounded"
+              >
+                <Icon name="mdi:content-copy" size="16" />
+                <BaseTooltip bottom>Copy {{ propertyKey }}</BaseTooltip>
+              </BaseButton>
+            </li>
+
+            <!-- Drag Button -->
+            <li>
+              <BaseButton
+                size="xs"
+                bg-color="var(--surface-lightened)"
+                class="!rounded"
+              >
+                <Icon name="mdi:cursor-move" size="16" />
+                <BaseTooltip bottom>Move {{ propertyKey }}</BaseTooltip>
+              </BaseButton>
+            </li>
+          </ul>
         </span>
       </div>
 

--- a/components/base/Tooltip.vue
+++ b/components/base/Tooltip.vue
@@ -134,7 +134,10 @@ tool-tip {
 
 :has(> tool-tip) {
   position: relative;
-  z-index: 20;
+
+  &:is(:hover, :focus-visible, :active) {
+    z-index: 20;
+  }
 }
 
 :has(> tool-tip):is(:hover, :focus-visible, :active) > tool-tip {


### PR DESCRIPTION
**This branch contains the following changes:**

- Added property control button list - copy & moved buttons added.
- Removed unneeded "break" in button size switch statement.
- Updated tool-tip CSS to only increase parent z-index on hover, focus-visible, and active states.