### PR TITLE
0.8.4/improvement/copied list animations

### DIFF
--- a/components/base/Card.vue
+++ b/components/base/Card.vue
@@ -233,6 +233,7 @@ const updatePropertyValue = (
           <BaseInput
             v-else
             :value="Object.keys(data.value)[index]"
+            class="max-w-80 w-full"
             @blur="(event: Event) => updatePropertyValue(event, index, 'update:property-key')"
             @keypress.enter="(event: Event) => updatePropertyValue(event, index, 'update:property-key')"
             @focusout="handleFocusout"
@@ -247,6 +248,7 @@ const updatePropertyValue = (
           <BaseInput
             v-else
             :value="Object.values(data.value)[index]"
+            class="max-w-80 w-full"
             @blur="(event: Event) => updatePropertyValue(event, index, 'update:property-value')"
             @keypress.enter="(event: Event) => updatePropertyValue(event, index, 'update:property-value')"
             @focusout="handleFocusout"
@@ -255,7 +257,7 @@ const updatePropertyValue = (
           <!-- Property buttons -->
           <ul
             v-if="isEditingCard.status"
-            class="ml-auto flex gap-1.5 items-center"
+            class="ml-auto flex gap-1.5 items-center w-fit"
           >
             <!-- Copy Button -->
             <li>
@@ -265,7 +267,7 @@ const updatePropertyValue = (
                 class="!rounded"
                 @click="emits('copy:property', propertyKey)"
               >
-                <Icon name="mdi:content-copy" size="16" />
+                <Icon name="mdi:content-copy" size="16" class="min-w-4" />
                 <BaseTooltip bottom>Copy {{ propertyKey }}</BaseTooltip>
               </BaseButton>
             </li>
@@ -277,7 +279,7 @@ const updatePropertyValue = (
                 bg-color="var(--surface-lightened)"
                 class="!rounded"
               >
-                <Icon name="mdi:cursor-move" size="16" />
+                <Icon name="mdi:cursor-move" size="16" class="min-w-4" />
                 <BaseTooltip bottom>Move {{ propertyKey }}</BaseTooltip>
               </BaseButton>
             </li>
@@ -290,7 +292,7 @@ const updatePropertyValue = (
                 class="!rounded"
                 @click="emits('delete:property', propertyKey)"
               >
-                <Icon name="mdi:delete" size="16" />
+                <Icon name="mdi:delete" size="16" class="min-w-4" />
                 <BaseTooltip bottom>Delete {{ propertyKey }}</BaseTooltip>
               </BaseButton>
             </li>

--- a/components/drawer/Copy.vue
+++ b/components/drawer/Copy.vue
@@ -22,19 +22,20 @@ watch(
     opening-direction="left"
     class="absolute right-0 bg-[var(--surface-default)] lg:relative h-full"
   >
-    <div class="py-2 px-4 border-[var(--surface-lightened)] border-l h-full">
+    <div class="py-4 px-4 border-[var(--surface-lightened)] border-l h-full">
       <transition-group
-        name=""
-        class="flex flex-col gap-3 w-[min(400px,_30vw)] lg:w-[min(400px,_15vw)] xl:w-[min(400px,_20vw)]"
+        tag="ul"
+        name="list-fade"
+        class="w-[min(400px,_30vw)] lg:w-[min(400px,_15vw)] xl:w-[min(400px,_20vw)]"
       >
         <li
           v-for="(property, index) in copiedProperties"
-          :key="index"
+          :key="JSON.stringify(property)"
           class="copied-property"
           draggable="true"
         >
-          <div>
-            <span>{{ Object.keys(property)[0] }}: </span>
+          <div class="flex gap-2 items-start">
+            <span class="font-bold">{{ Object.keys(property)[0] }}: </span>
             <span>{{ Object.values(property)[0] }}</span>
           </div>
 
@@ -42,7 +43,7 @@ watch(
           <BaseButton
             size="xs"
             bg-color="var(--surface-lightened)"
-            class="!rounded"
+            class="!rounded h-fit"
             @click="copiedDataStore.removeCopiedProperty(index)"
           >
             <Icon name="mdi:close" size="16" />
@@ -82,11 +83,18 @@ watch(
 </template>
 
 <style scoped>
+ul {
+  position: relative;
+}
+
 .copied-property {
-  display: flex;
-  justify-content: space-between;
+  margin-bottom: 0.75rem;
   padding-inline: 0.5rem;
   padding-block: 0.375rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
   background-color: var(--surface-lightened);
   border-radius: 6px;
   width: 100%;
@@ -97,6 +105,7 @@ watch(
   }
 }
 
+/* Transitions */
 .button-fade-enter-active {
   transition: 250ms ease 500ms;
 }
@@ -108,5 +117,23 @@ watch(
 .button-fade-enter-from,
 .button-fade-leave-to {
   opacity: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .list-fade-move,
+  .list-fade-enter-active,
+  .list-fade-leave-active {
+    transition: all 200ms ease;
+  }
+
+  .list-fade-enter-from,
+  .list-fade-leave-to {
+    opacity: 0;
+    transform: translateX(2rem);
+  }
+
+  .list-fade-leave-active {
+    position: absolute;
+  }
 }
 </style>

--- a/components/drawer/Copy.vue
+++ b/components/drawer/Copy.vue
@@ -20,13 +20,13 @@ watch(
   <BaseDrawer
     ref="copyDrawer"
     opening-direction="left"
-    class="absolute right-0 bg-[var(--surface-default)] lg:relative h-full"
+    class="absolute right-0 bg-[var(--surface-default)] xl:relative h-full"
   >
     <div class="py-4 px-4 border-[var(--surface-lightened)] border-l h-full">
       <transition-group
         tag="ul"
         name="list-fade"
-        class="w-[min(400px,_30vw)] lg:w-[min(400px,_15vw)] xl:w-[min(400px,_20vw)]"
+        class="w-[min(400px,_65vw)] xl:w-[min(400px,_30vw)]"
       >
         <li
           v-for="(property, index) in copiedProperties"
@@ -46,7 +46,7 @@ watch(
             class="!rounded h-fit"
             @click="copiedDataStore.removeCopiedProperty(index)"
           >
-            <Icon name="mdi:close" size="16" />
+            <Icon name="mdi:close" size="16" class="min-w-4" />
             <BaseTooltip bottom-left
               >Remove {{ Object.keys(property)[0] }}</BaseTooltip
             >

--- a/components/drawer/Copy.vue
+++ b/components/drawer/Copy.vue
@@ -23,7 +23,8 @@ watch(
     class="absolute right-0 bg-[var(--surface-default)] lg:relative h-full"
   >
     <div class="py-2 px-4 border-[var(--surface-lightened)] border-l h-full">
-      <ul
+      <transition-group
+        name=""
         class="flex flex-col gap-3 w-[min(400px,_30vw)] lg:w-[min(400px,_15vw)] xl:w-[min(400px,_20vw)]"
       >
         <li
@@ -50,7 +51,7 @@ watch(
             >
           </BaseButton>
         </li>
-      </ul>
+      </transition-group>
     </div>
 
     <template #button>
@@ -68,7 +69,7 @@ watch(
     </template>
   </BaseDrawer>
 
-  <transition name="test">
+  <transition name="button-fade">
     <BaseButton
       v-if="!copyDrawer?.isOpen && copiedProperties.length > 0"
       size="sm"
@@ -96,16 +97,16 @@ watch(
   }
 }
 
-.test-enter-active {
+.button-fade-enter-active {
   transition: 250ms ease 500ms;
 }
 
-.test-leave-active {
+.button-fade-leave-active {
   transition: 0ms ease;
 }
 
-.test-enter-from,
-.test-leave-to {
+.button-fade-enter-from,
+.button-fade-leave-to {
   opacity: 0;
 }
 </style>


### PR DESCRIPTION
**This branch contains the following changes:**

- Added transition group with animations to copy drawer list
- Updated styles and responsiveness breakpoints for the copy drawer and its list items.
- Changed buttons transition name from test to button-fade.
- Fixed property item sizing when editing cards.